### PR TITLE
fix: fix tslint-eslint-rules to v5.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "deep-strict-equal": "^0.2.0",
     "eslint": "^5.3.0",
     "object.entries": "^1.0.4",
-    "tslint-eslint-rules": "^5.3.1"
+    "tslint-eslint-rules": "5.3.1"
   },
   "devDependencies": {
     "eslint-config-teppeis": "^8.2.0",


### PR DESCRIPTION
v5.4.0 doesn't include `dist/readme` https://github.com/buzinas/tslint-eslint-rules/pull/352